### PR TITLE
Tune the dispatcher and receiver.

### DIFF
--- a/cmd/send/main.go
+++ b/cmd/send/main.go
@@ -47,7 +47,7 @@ func main() {
 	client := workqueue.NewWorkqueueServiceClient(conn)
 
 	eg := errgroup.Group{}
-	eg.SetLimit(runtime.GOMAXPROCS(0))
+	eg.SetLimit(5 * runtime.GOMAXPROCS(0))
 	for i := 0; i < *requests; i++ {
 		i := i
 		eg.Go(func() error {

--- a/dispatcher/handler.go
+++ b/dispatcher/handler.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2024 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dispatcher
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/mattmoor/go-workqueue"
+)
+
+func Handler(wq workqueue.Interface, concurrency uint, f Callback) http.Handler {
+	return &handler{
+		wq:          wq,
+		concurrency: concurrency,
+		f:           f,
+	}
+}
+
+type handler struct {
+	doWork sync.Mutex
+	doWait sync.Mutex
+
+	wq          workqueue.Interface
+	concurrency uint
+	f           Callback
+}
+
+var _ http.Handler = (*handler)(nil)
+
+// ServeHTTP implements http.Handler
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// If something else is already dispatching, then we enter the waiting room.
+	if !h.doWork.TryLock() {
+		// If there is already someone in the waiting room, then we deduplicate
+		// ourselves with that event by returning and allowing the waiting
+		// request to trigger any subsequent processing.
+		if !h.doWait.TryLock() {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		// As the waiting room occupant, wait patiently to acquire the work lock
+		// and once we have it, then we can vacate the waiting room.
+		// Note: it is conceivably possible for two races to occur:
+		// 1. A new request acquires the lock instead of us, and we continue to
+		//   occupy the waiting room.
+		// 2. A new request comes in while we hold both locks, and nothing fills
+		//   the waiting room.
+		// In both of these cases, there isn't really a risk of data loss, so
+		// this is acceptable.
+		h.doWork.Lock()
+		h.doWait.Unlock()
+	}
+
+	// Launch the dispatch future while holding the lock.
+	future := func() Future {
+		// We do this via a defer to ensure that it is invoked in the event of
+		// a panic during HandleAsync.
+		defer h.doWork.Unlock()
+		return HandleAsync(r.Context(), h.wq, h.concurrency, h.f)
+	}()
+
+	// Once we have initiated the dispatch, allow other dispatches to
+	// initiate while we wait on this round of results.
+	if err := future(); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/iac/receiver.tf
+++ b/iac/receiver.tf
@@ -31,6 +31,12 @@ module "receiver-service" {
         working_dir = path.module
         importpath  = "github.com/mattmoor/go-workqueue/cmd/receiver"
       }
+      resources = {
+        limits = {
+          memory = "4Gi"
+          cpu    = "1000m"
+        }
+      }
       ports = [{ container_port = 8080 }]
       env = [
         {


### PR DESCRIPTION
Adjust the receiver's resources which was OOMing under heavy load.

Teach the dispatcher to only perform a single concurrent enumeration to limit the memory pressure due to parallel enumerations.  This also sheds all remaining load except for a single "waiting room" request beyond the active dispatch.

Increase the parallelism of the trivial loadgen client.